### PR TITLE
v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Number-only variant
 - Add option to `selectTextOnFocus`
 - Export reactive `completed` prop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Add option to `selectTextOnFocus`
-- Export reactive `completed` prop
 
 ## [0.2.0](https://github.com/metonym/svelte-pincode/releases/tag/v0.2.0) - 2021-01-01
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ npm i -D svelte-pincode
 
 Bind to either the `code` or `value` prop.
 
-- **`code`** (`string[]`): Array of input values. An empty string represents an undefined value.
-- **`value`** (`string`): The `code` props as a string (i.e., `code.join('')`)
+- **`code`** (`string[]`): Array of input values. An empty string represents an undefined value
+- **`value`** (`string`): `code` joined as a string
 
 <!-- prettier-ignore-start -->
 ```svelte
@@ -50,7 +50,7 @@ Bind to either the `code` or `value` prop.
 
 By default, this component accepts alphanumeric values.
 
-Set `type="numeric"` to only allow numbers (i.e., `0-9`).
+Set `type` to `"numeric"` to only allow numbers.
 
 <!-- prettier-ignore-start -->
 ```svelte
@@ -84,13 +84,11 @@ Define intitial input values by using the `code` prop or `value` prop on `Pincod
 ```
 <!-- prettier-ignore-end -->
 
-### Completion & error states
+### Validating upon completion
 
-Validation is left to the consumer.
+Actual validation is left to the consumer.
 
-This example illustrates how you can validate the code once all inputs have a value.
-
-`value` is simply the `code` array joined as a string.
+This example illustrates how you can validate the code once all inputs have a value by binding to the `complete` prop.
 
 <!-- prettier-ignore-start -->
 ```svelte
@@ -98,13 +96,13 @@ This example illustrates how you can validate the code once all inputs have a va
   const correctCode = "1234";
 
   let inputValue = '';
+  let complete = false;
 
-  $: complete = inputValue.length === correctCode.length;
   $: success = complete && inputValue === correctCode;
   $: error = complete && !success;
 </script>
 
-<Pincode bind:value={inputValue}>
+<Pincode bind:complete bind:value={inputValue}>
   <PincodeInput />
   <PincodeInput />
   <PincodeInput />
@@ -120,6 +118,16 @@ This example illustrates how you can validate the code once all inputs have a va
 </div>
 ```
 <!-- prettier-ignore-end -->
+
+As an alternative to the `complete` prop, you can listen to the dispatched "complete" event:
+
+```html
+<Pincode
+  on:complete="{(e) => {
+    console.log(e.detail); // { code: string[]; value: string; }
+  }}"
+/>
+```
 
 ### Programmatic usage
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ Bind to either the `code` or `value` prop.
 ```
 <!-- prettier-ignore-end -->
 
+### Numeric variant
+
+By default, this component accepts alphanumeric values.
+
+Set `type="numeric"` to only allow numbers (i.e., `0-9`).
+
+<!-- prettier-ignore-start -->
+```svelte
+<Pincode type="numeric">
+  <PincodeInput />
+  <PincodeInput />
+  <PincodeInput />
+  <PincodeInput />
+</Pincode>
+```
+<!-- prettier-ignore-end -->
+
 ### Initial values
 
 Define intitial input values by using the `code` prop or `value` prop on `PincodeInput`.
@@ -68,6 +85,8 @@ Define intitial input values by using the `code` prop or `value` prop on `Pincod
 <!-- prettier-ignore-end -->
 
 ### Completion & error states
+
+Validation is left to the consumer.
 
 This example illustrates how you can validate the code once all inputs have a value.
 
@@ -246,13 +265,14 @@ input:not(:last-of-type) {
 
 #### Props
 
-| Prop name           | Value                      |
-| :------------------ | :------------------------- |
-| code                | `string[]` (default: `[]`) |
-| value               | `string` (default: `""`)   |
-| focusFirstInput     | `() => void`               |
-| focusNextEmptyInput | `() => void`               |
-| focusLastInput      | `() => void`               |
+| Prop name           | Value                                                      |
+| :------------------ | :--------------------------------------------------------- |
+| code                | `string[]` (default: `[]`)                                 |
+| value               | `string` (default: `""`)                                   |
+| type                | `"alphanumeric"` or `"numeric"` (defaul: `"alhpanumeric"`) |
+| focusFirstInput     | `() => void`                                               |
+| focusNextEmptyInput | `() => void`                                               |
+| focusLastInput      | `() => void`                                               |
 
 #### Dispatched Events
 
@@ -268,6 +288,8 @@ input:not(:last-of-type) {
 
 ### PincodeInput
 
+#### Props
+
 | Prop name | Value                                                      |
 | :-------- | :--------------------------------------------------------- |
 | id        | `string` (default: `"input" + Math.random().toString(36)`) |
@@ -277,12 +299,11 @@ input:not(:last-of-type) {
 
 - on:focus
 - on:blur
-- on:input
 - on:keydown
 
 ## TypeScript
 
-To use this component with TypeScript, you will need `svelte` version 3.31 or greater.
+`svelte` version 3.31 or greater is required to use this component with TypeScript.
 
 ## Changelog
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "svelte-check": "svelte-check"
   },
   "devDependencies": {
-    "svelte": "^3.31.0",
+    "svelte": "^3.31.1",
     "svelte-check": "^1.1.24",
     "svelte-readme": "^2.1.2"
   },

--- a/src/Pincode.svelte
+++ b/src/Pincode.svelte
@@ -9,6 +9,9 @@
 
   export let value = "";
 
+  /** @type {"alphanumeric" | "numeric"} */
+  export let type = "alphanumeric";
+
   /** @type {() => void} */
   export const focusFirstInput = () => {
     ref.querySelector("input").focus();
@@ -37,6 +40,7 @@
   const _valuesById = derived(_ids, (_) => {
     return _.reduce((a, c) => ({ ...a, [c.id]: c.value }), {});
   });
+  const _type = writable(type);
 
   let ref = null;
 
@@ -45,6 +49,7 @@
   }
 
   setContext("Pincode", {
+    _type,
     _valuesById,
     add: (id, value) => {
       let _code = [...code];
@@ -114,6 +119,8 @@
       setCode();
     },
   });
+
+  $: _type.set(type);
 
   $: value = code.join("");
 

--- a/src/Pincode.svelte
+++ b/src/Pincode.svelte
@@ -51,9 +51,26 @@
     code = $_ids.map((_) => _.value || "");
   }
 
+  function focusNextInput(idx) {
+    const inputs = ref.querySelectorAll("input");
+
+    if (idx === inputs.length - 1) {
+      return inputs[idx].blur();
+    }
+
+    const nextInput = inputs[idx + 1];
+
+    if (nextInput) nextInput.focus();
+  }
+
   setContext("Pincode", {
     _type,
     _valuesById,
+    focusNextInput: (id) => {
+      const idx = $_ids.map((_) => _.id).indexOf(id);
+
+      focusNextInput(idx);
+    },
     add: (id, value) => {
       let _code = [...code];
 
@@ -90,11 +107,7 @@
       });
 
       setCode();
-
-      const inputs = ref.querySelectorAll("input");
-      const nextInput = inputs[idx + 1];
-
-      if (nextInput) nextInput.focus();
+      focusNextInput(idx);
 
       await tick();
 

--- a/src/PincodeInput.svelte
+++ b/src/PincodeInput.svelte
@@ -6,7 +6,12 @@
 
   import { getContext, onMount } from "svelte";
 
+  let type;
+
   const ctx = getContext("Pincode");
+  const unsubscribeType = ctx._type.subscribe((_type) => {
+    type = _type;
+  });
 
   let unsubscribe = undefined;
 
@@ -20,6 +25,7 @@
     return () => {
       ctx.remove(id);
       unsubscribe();
+      unsubscribeType();
     };
   });
 </script>
@@ -46,22 +52,23 @@
 <input
   bind:this="{ref}"
   {...$$restProps}
-  type="text"
-  inputmode="numeric"
-  pattern="[0-9]{1}"
+  type="{type === 'numeric' ? 'number' : 'text'}"
+  inputmode="{type === 'numeric' ? 'numeric' : 'text'}"
+  pattern="{type === 'numeric' ? '[0-9]{1}' : '^[a-zA-Z0-9]$'}"
   maxlength="1"
   value="{value}"
   on:focus
   on:blur
-  on:input
-  on:input="{(e) => {
-    ctx.update(id, e.target.value);
-  }}"
   on:keydown
-  on:keydown="{(e) => {
-    if (e.key === 'Backspace') {
-      e.preventDefault();
-      ctx.clear(id);
+  on:keydown|preventDefault="{(e) => {
+    if (e.key === 'Backspace') return ctx.clear(id);
+
+    if (type === 'numeric' && /^[0-9]$/.test(e.key)) {
+      ctx.update(id, e.key);
+    }
+
+    if (type === 'alphanumeric' && /^[a-zA-Z0-9]$/.test(e.key)) {
+      ctx.update(id, e.key);
     }
   }}"
 />

--- a/src/PincodeInput.svelte
+++ b/src/PincodeInput.svelte
@@ -61,6 +61,8 @@
   on:blur
   on:keydown
   on:keydown|preventDefault="{(e) => {
+    if (e.key === 'Tab') return ctx.focusNextInput(id);
+
     if (e.key === 'Backspace') return ctx.clear(id);
 
     if (type === 'numeric' && /^[0-9]$/.test(e.key)) {

--- a/types/Pincode.d.ts
+++ b/types/Pincode.d.ts
@@ -15,6 +15,11 @@ export interface PincodeProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNa
   value?: string;
 
   /**
+   * @default "alphanumeric"
+   */
+  type?: "alphanumeric" | "numeric";
+
+  /**
    * @constant
    * @default () => { ref.querySelector("input").focus(); }
    */

--- a/types/Pincode.d.ts
+++ b/types/Pincode.d.ts
@@ -20,6 +20,12 @@ export interface PincodeProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNa
   type?: "alphanumeric" | "numeric";
 
   /**
+   * `true` if all inputs have a value
+   * @default false
+   */
+  complete?: boolean;
+
+  /**
    * @constant
    * @default () => { ref.querySelector("input").focus(); }
    */

--- a/types/PincodeInput.d.ts
+++ b/types/PincodeInput.d.ts
@@ -23,7 +23,6 @@ export default class PincodeInput extends SvelteComponentTyped<
   {
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
-    input: WindowEventMap["input"];
     keydown: WindowEventMap["keydown"];
   },
   {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -759,10 +759,10 @@ svelte-readme@^2.1.2:
     rollup-plugin-svelte "^7.0.0"
     rollup-plugin-terser "^7.0.2"
 
-svelte@^3.31.0:
-  version "3.31.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.31.0.tgz#13966e5f55b975bc86675469bb2c58dd0e558d97"
-  integrity sha512-r+n8UJkDqoQm1b+3tA3Lh6mHXKpcfOSOuEuIo5gE2W9wQYi64RYX/qE6CZBDDsP/H4M+N426JwY7XGH4xASvGQ==
+svelte@^3.31.1:
+  version "3.31.1"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.31.1.tgz#1a1e2a2fe4eeb72be5c2542735e035c49c45be87"
+  integrity sha512-Q8xVz5U/IFFNjgvVSjdzKJPAX0MFytFwiJo1HAPfGwM7LkHA+BN2q2kL8vKcJwjku7/509MapLov8C9SjogNRg==
 
 terser@^5.0.0:
   version "5.5.1"


### PR DESCRIPTION
**Features**

- add Pincode `type` prop; default value is "alphanumeric"
- support numeric variant by setting `type="numeric"`
- add reactive Pincode `complete` prop 
- remove forwarded `input` event from PincodeInput

**Fixes**

- fix the incorrect value being dispatched in the `on:complete` event detail