### PR TITLE
Remove whitespace around and between when pasting.

### DIFF
--- a/src/Pincode.svelte
+++ b/src/Pincode.svelte
@@ -143,7 +143,7 @@
 
   function handlePaste(e) {
     e.preventDefault();
-    code = e.clipboardData.getData("text").split("");
+    code = e.clipboardData.getData("text").split("").filter(it => it !== " ");
   }
 
   $: _type.set(type);

--- a/src/unstyled/Pincode.svelte
+++ b/src/unstyled/Pincode.svelte
@@ -143,7 +143,7 @@
 
   function handlePaste(e) {
     e.preventDefault();
-    code = e.clipboardData.getData("text").split("");
+    code = e.clipboardData.getData("text").split("").filter(it => it !== " ");
   }
 
   $: _type.set(type);


### PR DESCRIPTION
**Tested paste inputs:**

1. 123456_
2. 1_2_3_4_5_6

(using _ here just to signify where the whitespace is)

**Results**

string representation: 123456 (no trailing whitespace)
array representation: ['1', '2', '3', '4', '5', '6']

I am very fresh to the svelte world so I am not sure if this is how you'd like it to be done or how to run/display or extend your test.
What do you think? Should cutting whitespaces between be conditional/configurable? Personally I have not seen such codes in the wild yet.