### PR TITLE
Resolves missing exports condition #22

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,24 @@
   "license": "MIT",
   "description": "Declarative pin code component for Svelte",
   "author": "Eric Liu (https://github.com/metonym)",
-  "main": "./src/index.js",
-  "types": "./src/index.d.ts",
-  "sideEffects": false,
+  "svelte": "./index.js",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "svelte": "./index.js"
+    },
+    "./*.svelte": {
+      "types": "./*.svelte.d.ts",
+      "import": "./*.svelte"
+    },
+    "./unstyled/*.svelte": {
+      "types": "./unstyled/*.svelte.d.ts",
+      "import": "./*.svelte"
+    }
+  },
   "scripts": {
     "dev": "rollup -cw",
     "predeploy": "rollup -c",
@@ -40,10 +55,5 @@
     "svelteStrictMode": true,
     "svelteBracketNewLine": true
   },
-  "type": "module",
-  "exports": {
-    ".": {
-      "svelte": "./src/index.js"
-    }
-  }
+  "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "description": "Declarative pin code component for Svelte",
   "author": "Eric Liu (https://github.com/metonym)",
-  "svelte": "./src/index.js",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "sideEffects": false,
@@ -41,5 +40,10 @@
     "svelteStrictMode": true,
     "svelteBracketNewLine": true
   },
-  "type": "module"
+  "type": "module",
+  "exports": {
+    ".": {
+      "svelte": "./src/index.js"
+    }
+  }
 }


### PR DESCRIPTION
Fixes #22  "WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte."

- Remove "svelte" Field in package.json
- Add export in package.json according to  https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition

