### PR TITLE
fix: correctly map `/unstyled/*.svelte` imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,12 +314,12 @@ This component is minimally styled; override the default styles by targeting the
 
 ### Unstyled components
 
-Use the unstyled components located in the `svelte/src/unstyled` folder if you prefer to style the components from scratch.
+Use the unstyled components located in the `svelte-pincode/unstyled` folder if you prefer to style the components from scratch.
 
 ```html
 <script>
-  import Pincode from "svelte-pincode/src/unstyled/Pincode.svelte";
-  import PincodeInput from "svelte-pincode/src/unstyled/PincodeInput.svelte";
+  import Pincode from "svelte-pincode/unstyled/Pincode.svelte";
+  import PincodeInput from "svelte-pincode/unstyled/PincodeInput.svelte";
 </script>
 ```
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./unstyled/*.svelte": {
       "types": "./src/unstyled/*.svelte.d.ts",
-      "import": "./src/*.svelte"
+      "import": "./src/unstyled/*.svelte"
     }
   },
   "scripts": {


### PR DESCRIPTION
Fixes #22

There's a typo in the `package.json#exports` map for `unstyled` imports. It currently maps to the *styled* imports. The README should also be updated, as the `src/*` prefix is no longer needed.